### PR TITLE
Fixed compile error in VS 2017

### DIFF
--- a/lbfgs/lbfgs.cu
+++ b/lbfgs/lbfgs.cu
@@ -19,6 +19,7 @@
 #include "timer.h"
 
 #include <iostream>
+#include <algorithm>
 #include <limits>
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
lbfgs seems to compile beautifully on various *nix systems but I needed to include <algorithm> in order for std::max and std::min to resolve on a Visual Studio 2017 build